### PR TITLE
Feat/adding deployment annotations

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -144,6 +144,7 @@ Kubernetes: `>=1.22.0-0`
 | clusterNetworks | string | `"10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16,fd00::/8"` | The cluster networks for which service discovery is performed. This should include the pod and service networks, but need not include the node network.  By default, all IPv4 private networks and all accepted IPv6 ULAs are specified so that resolution works in typical Kubernetes environments. |
 | cniEnabled | bool | `false` | enabling this omits the NET_ADMIN capability in the PSP and the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed |
 | commonLabels | object | `{}` | Labels to apply to all resources |
+| commonDeploymentAnnotations | object | `{}` | Annotations to be appended to control plane deployments |
 | controlPlaneTracing | bool | `false` | enables control plane tracing |
 | controlPlaneTracingNamespace | string | `"linkerd-jaeger"` | namespace to send control plane traces to |
 | controller.podDisruptionBudget | object | `{"maxUnavailable":1}` | sets pod disruption budget parameter for all deployments |

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -136,6 +136,7 @@ kind: Deployment
 metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    {{- with .Values.commonDeploymentAnnotations }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   labels:
     app.kubernetes.io/name: destination
     app.kubernetes.io/part-of: Linkerd

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -110,6 +110,7 @@ kind: Deployment
 metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    {{- with .Values.commonDeploymentAnnotations }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   labels:
     app.kubernetes.io/name: identity
     app.kubernetes.io/part-of: Linkerd

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -17,6 +17,7 @@ kind: Deployment
 metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    {{- with .Values.commonDeploymentAnnotations }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   labels:
     app.kubernetes.io/name: proxy-injector
     app.kubernetes.io/part-of: Linkerd

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -73,6 +73,8 @@ podAnnotations: {}
 podLabels: {}
 # -- Labels to apply to all resources
 commonLabels: {}
+# -- Additional annotations to add to all deployments
+commonDeploymentAnnotations: {}
 # -- Kubernetes priorityClassName for the Linkerd Pods
 priorityClassName: ""
 # -- Runtime Class Name for all the pods
@@ -668,4 +670,3 @@ podMonitor:
 egress:
   # -- The namespace that is used to store egress configuration that affects all client workloads in the cluster
   globalEgressNetworkNamespace: linkerd-egress
-  


### PR DESCRIPTION
Adding custom deployment annotations to control plane helm charts

There is no option to add custom deployment annotations to the control plane

Enhance the helm  values.yaml to add a commonDeploymentAnnotations object following the commonLabels approach.

Documentation and templated helm chart

Fixes [#13317](https://github.com/linkerd/linkerd2/issues/13317)

Signed-off-by: Gustavo Vera Heredia <gustavo.vera_heredia@mercedes-benz.com>
